### PR TITLE
Change the value of `nbrFreelansers` (sic) to `1150`

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -4,7 +4,7 @@ import Link from 'next/link'
 
 import styles from '../styles/Home.module.css'
 
-const nbrFreelansers = 1061
+const nbrFreelansers = 1150
 
 const ArrowRight = () => (
   <svg


### PR DESCRIPTION
The current number of members in `#general` is `1153`, but the wording on the site makes me think the count should not be **exact** now that we have a fair amount of members joining.