### PR TITLE
Clarify freelancing requirement in application form

### DIFF
--- a/pages/ansokan/RequestSlackInvitationForm.module.css
+++ b/pages/ansokan/RequestSlackInvitationForm.module.css
@@ -29,8 +29,7 @@
   display: flex;
   flex-direction: row;
   justify-content: start;
-  align-items: center;
-  height: 20px;
+  align-items: baseline;
 }
 
 .flex {
@@ -42,7 +41,6 @@
 }
 
 .label {
-  margin: 4em 0;
   line-height: 1.5;
   font-size: 1.1em;
 }

--- a/pages/ansokan/RequestSlackInvitationForm.tsx
+++ b/pages/ansokan/RequestSlackInvitationForm.tsx
@@ -97,7 +97,8 @@ const RequestSlackInvitationForm = () => {
             className={classNames(styles.label, styles.flex)}
             htmlFor="freelancer-confirmation"
           >
-            Jag är frilansare
+            Jag är igång som frilansare, d v s har ett bolag att fakturera genom
+            och tecknat avtal med åtminstone min första kund.
           </label>
         </div>
 

--- a/pages/ansokan/RequestSlackInvitationForm.tsx
+++ b/pages/ansokan/RequestSlackInvitationForm.tsx
@@ -47,7 +47,7 @@ const RequestSlackInvitationForm = () => {
         <div className={styles.item}>
           <div>
             <label className={styles.label} htmlFor="email">
-              Email
+              E-mail
             </label>
           </div>
           <input


### PR DESCRIPTION
Make applicant aware of requirements for membership. This will most likely reduce the number of applications from people who have just started their business.

<img width="959" height="999" alt="image" src="https://github.com/user-attachments/assets/e26d1afd-5849-410f-9aea-d5d26fbbc3d4" />
