### PR TITLE
fix(styles) Fix checkbox in Safari looking wonky

### DIFF
--- a/styles/globals.css
+++ b/styles/globals.css
@@ -124,6 +124,10 @@ textarea {
   transition: box-shadow 0.15s;
 }
 
+input[type="checkbox"] {
+  width: auto;
+}
+
 input:focus,
 textarea:focus {
   box-shadow: 0 0 0 0.1em var(--white), 0 0 0 0.2em var(--blue);


### PR DESCRIPTION
I've fixed the width for checkboxes on the application page since the `width: 100%` was causing it to go out of bounds in Safari.

**Before:**

<img width="781" height="827" alt="Screenshot 2026-01-21 at 11 06 11" src="https://github.com/user-attachments/assets/ac18511b-c5f6-42d9-9150-8d2a6f84bbec" />

**After:**

<img width="687" height="540" alt="Screenshot 2026-01-21 at 11 06 16" src="https://github.com/user-attachments/assets/567aeccb-ab05-42b9-88ee-8cd391e938ae" />

